### PR TITLE
add a 'source_type' tag to the event output

### DIFF
--- a/cronner.go
+++ b/cronner.go
@@ -134,7 +134,7 @@ func emitEvent(title, body, alertType, uuidStr string, g *godspeed.Godspeed) {
 		fields["aggregation_key"] = uuidStr
 	}
 
-	g.Event(title, body, fields, nil)
+	g.Event(title, body, fields, []string{"source_type:cron"})
 }
 
 func main() {

--- a/cronner_test.go
+++ b/cronner_test.go
@@ -206,10 +206,10 @@ func (t *TestSuite) Test_emitEvent(c *C) {
 	event, ok := <-t.out
 	c.Assert(ok, Equals, true)
 
-	eventStub := fmt.Sprintf("_e{%d,%d}:%v|%v|k:%v|s:cron|t:%v", len(title), len(body), title, body, uuidStr, alertType)
+	eventStub := fmt.Sprintf("_e{%d,%d}:%v|%v|k:%v|s:cron|t:%v|#source_type:cron", len(title), len(body), title, body, uuidStr, alertType)
 	eventStr := string(event)
 
-	c.Assert(eventStr, Equals, eventStub)
+	c.Check(eventStr, Equals, eventStub)
 
 	//
 	// Test truncation
@@ -228,10 +228,10 @@ func (t *TestSuite) Test_emitEvent(c *C) {
 	// simulate truncation and addition of the truncation messsage
 	truncatedBody := fmt.Sprintf("%v...\\n=== OUTPUT TRUNCATED ===\\n%v", body[0:MaxBody/2], body[len(body)-((MaxBody/2)+1):len(body)-1])
 
-	eventStub = fmt.Sprintf("_e{%d,%d}:%v|%v|k:%v|s:cron|t:%v", len(title), len(truncatedBody), title, truncatedBody, uuidStr, alertType)
+	eventStub = fmt.Sprintf("_e{%d,%d}:%v|%v|k:%v|s:cron|t:%v|#source_type:cron", len(title), len(truncatedBody), title, truncatedBody, uuidStr, alertType)
 	eventStr = string(event)
 
-	c.Assert(eventStr, Equals, eventStub)
+	c.Check(eventStr, Equals, eventStub)
 }
 
 //


### PR DESCRIPTION
Unfortunately, it doesn't seem like DataDog is going to support filtering events by the source type value. However, you can filter by tag. So, we just add a `source_type` tag. I wanted to avoid using the same name as the event field in case there ever is a collision.
