### PR TITLE
add label_name tag to cronner event submission

### DIFF
--- a/cronner.go
+++ b/cronner.go
@@ -106,7 +106,7 @@ func runCommand(cmd *exec.Cmd, label string, gs *godspeed.Godspeed) (int, []byte
 }
 
 // emit a godspeed (dogstatsd) event
-func emitEvent(title, body, alertType, uuidStr string, g *godspeed.Godspeed) {
+func emitEvent(title, body, label, alertType, uuidStr string, g *godspeed.Godspeed) {
 	var buf bytes.Buffer
 
 	// if the event's body is bigger than MaxBody
@@ -134,7 +134,9 @@ func emitEvent(title, body, alertType, uuidStr string, g *godspeed.Godspeed) {
 		fields["aggregation_key"] = uuidStr
 	}
 
-	g.Event(title, body, fields, []string{"source_type:cron"})
+	tags := []string{"source_type:cron", fmt.Sprintf("label_name:%v", label)}
+
+	g.Event(title, body, fields, tags)
 }
 
 func main() {
@@ -185,7 +187,7 @@ func main() {
 	if opts.AllEvents {
 		uuidStr = uuid.New()
 		// emit a DD event to indicate we are starting the job
-		emitEvent(fmt.Sprintf("Cron %v starting on %v", opts.Label, hostname), "job starting", "info", uuidStr, gs)
+		emitEvent(fmt.Sprintf("Cron %v starting on %v", opts.Label, hostname), "job starting", opts.Label, "info", uuidStr, gs)
 	}
 
 	// run the command and return the output as well as the return status
@@ -231,6 +233,6 @@ func main() {
 			uuidStr = uuid.New()
 		}
 
-		emitEvent(title, body, alertType, uuidStr, gs)
+		emitEvent(title, body, opts.Label, alertType, uuidStr, gs)
 	}
 }

--- a/cronner_test.go
+++ b/cronner_test.go
@@ -198,15 +198,16 @@ func (t *TestSuite) Test_runCommand(c *C) {
 func (t *TestSuite) Test_emitEvent(c *C) {
 	title := "TE"
 	body := "B"
+	label := "urmom"
 	alertType := "info"
 	uuidStr := uuid.New()
 
-	emitEvent(title, body, alertType, uuidStr, t.gs)
+	emitEvent(title, body, label, alertType, uuidStr, t.gs)
 
 	event, ok := <-t.out
 	c.Assert(ok, Equals, true)
 
-	eventStub := fmt.Sprintf("_e{%d,%d}:%v|%v|k:%v|s:cron|t:%v|#source_type:cron", len(title), len(body), title, body, uuidStr, alertType)
+	eventStub := fmt.Sprintf("_e{%d,%d}:%v|%v|k:%v|s:cron|t:%v|#source_type:cron,label_name:urmom", len(title), len(body), title, body, uuidStr, alertType)
 	eventStr := string(event)
 
 	c.Check(eventStr, Equals, eventStub)
@@ -218,9 +219,10 @@ func (t *TestSuite) Test_emitEvent(c *C) {
 	// generate a body that will be truncated
 	body = randString(4100)
 	title = "TE2"
+	label = "awwyiss"
 	alertType = "success"
 
-	emitEvent(title, body, alertType, uuidStr, t.gs)
+	emitEvent(title, body, label, alertType, uuidStr, t.gs)
 
 	event, ok = <-t.out
 	c.Assert(ok, Equals, true)
@@ -228,7 +230,7 @@ func (t *TestSuite) Test_emitEvent(c *C) {
 	// simulate truncation and addition of the truncation messsage
 	truncatedBody := fmt.Sprintf("%v...\\n=== OUTPUT TRUNCATED ===\\n%v", body[0:MaxBody/2], body[len(body)-((MaxBody/2)+1):len(body)-1])
 
-	eventStub = fmt.Sprintf("_e{%d,%d}:%v|%v|k:%v|s:cron|t:%v|#source_type:cron", len(title), len(truncatedBody), title, truncatedBody, uuidStr, alertType)
+	eventStub = fmt.Sprintf("_e{%d,%d}:%v|%v|k:%v|s:cron|t:%v|#source_type:cron,label_name:awwyiss", len(title), len(truncatedBody), title, truncatedBody, uuidStr, alertType)
 	eventStr = string(event)
 
 	c.Check(eventStr, Equals, eventStub)


### PR DESCRIPTION
We may want to end up filtering / doing some intelligent alert routing based on the service (label). This adds the label as a tag so we can easily filter on that value.
