### PR TITLE
prep for open sourcing cronner; add statsd namespace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,29 +9,31 @@ When emitting a finished event, `cronner` provides the combined stdout and stder
 Help output:
 ```
 Usage:
-  cronner [OPTIONS]
+  cronner [OPTIONS] command [arguments]...
 
 Application Options:
-  -l, --label=      name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it
-  -c, --command=    command to run (please use full path) and its args; executed as user running cronner
-  -e, --event       emit a start and end datadog event (false)
-  -E, --event-fail  only emit an event on failure (false)
-  -F, --log-fail    when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename (false)
-      --log-path=   where to place the log files for command output (path for -l/--log-on-fail output) (/var/log/cronner/)
-  -L, --log-level=  set the level at which to log at [none|error|info|debug] (error)
-  -s, --sensitive   specify whether command output may contain sensitive details, this only avoids it being printed to stderr (false)
-  -k, --lock        lock based on label so that multiple commands with the same label can not run concurrently (false)
-  -d, --lock-dir=   the directory where lock files will be placed (/var/lock)
+  -l, --label=               name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it
+  -c, --command=             (deprecated; use positional args) command to run (please use full path) and its args; executed as user running cronner
+  -e, --event                emit a start and end datadog event (false)
+  -E, --event-fail           only emit an event on failure (false)
+  -F, --log-fail             when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename (false)
+      --log-path=            where to place the log files for command output (path for -l/--log-on-fail output) (/var/log/cronner/)
+  -L, --log-level=           set the level at which to log at [none|error|info|debug] (error)
+  -s, --sensitive            specify whether command output may contain sensitive details, this only avoids it being printed to stderr (false)
+  -k, --lock                 lock based on label so that multiple commands with the same label can not run concurrently (false)
+  -d, --lock-dir=            the directory where lock files will be placed (/var/lock)
+  -N, --namespace=           namespace for statsd emissions, value is prepended to metric name by statsd client (cronner)
 
 Help Options:
-  -h, --help        Show this help message
+  -h, --help                 Show this help message
 
-
+Arguments:
+  command [arguments]
 ```
 
 Running a command:
 ```
-$ cronner -c 'sleep 10' -l sleepytime
+$ cronner -l sleepytime -- /bin/sleep 10
 ```
 
 Listening to the statsd emissions looks like this:
@@ -46,7 +48,7 @@ It emits a timing metric for how long it took for the command to run, as well as
 Running a command and emitting a start and end event:
 
 ```
-$ cronner -e -l sleepytime2 -c 'sleep 5'
+$ cronner -e -l sleepytime2 -- /bin/sleep 5
 ```
 
 And the statsd interceptions look like this:

--- a/args.go
+++ b/args.go
@@ -16,7 +16,7 @@ import (
 // args is for argument parsing
 type args struct {
 	Label     string `short:"l" long:"label" default:"" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
-	Cmd       string `short:"c" long:"command" default:"" description:"command to run (please use full path) and its args; executed as user running cronner"`
+	Cmd       string `short:"c" long:"command" default:"" description:"(deprecated; use positional args) command to run (please use full path) and its args; executed as user running cronner"`
 	AllEvents bool   `short:"e" long:"event" default:"false" description:"emit a start and end datadog event"`
 	FailEvent bool   `short:"E" long:"event-fail" default:"false" description:"only emit an event on failure"`
 	LogFail   bool   `short:"F" long:"log-fail" default:"false" description:"when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename"`
@@ -25,14 +25,19 @@ type args struct {
 	Sensitive bool   `short:"s" long:"sensitive" default:"false" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
 	Lock      bool   `short:"k" long:"lock" default:"false" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
 	LockDir   string `short:"d" long:"lock-dir" default:"/var/lock" description:"the directory where lock files will be placed"`
+	Namespace string `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
+	Args      struct {
+		Command []string `positional-arg-name:"command [arguments]"`
+	} `positional-args:"yes" required:"true"`
 }
 
 // parse function configures the go-flags parser and runs it
 // it also does some light input validation
 func (a *args) parse() error {
 	p := flags.NewParser(a, flags.HelpFlag|flags.PassDoubleDash)
+	//p.Usage = Usage
 
-	leftOvers, err := p.Parse()
+	_, err := p.Parse()
 
 	// determine if there was a parsing error
 	// unfortunately, help message is returned as an error
@@ -41,7 +46,7 @@ func (a *args) parse() error {
 			logger.Errorf("error: %v\n", err)
 			os.Exit(1)
 		} else {
-			fmt.Printf("%v\n", err.Error())
+			fmt.Printf("%v", err.Error())
 			os.Exit(0)
 		}
 	}
@@ -53,10 +58,10 @@ func (a *args) parse() error {
 	}
 
 	if a.Cmd == "" {
-		if len(leftOvers) == 0 {
+		if len(a.Args.Command) == 0 {
 			return fmt.Errorf("you must specify a command to run either using by adding it to the end, or using the command flag")
 		}
-		a.Cmd = strings.Join(leftOvers, " ")
+		a.Cmd = strings.Join(a.Args.Command, " ")
 	}
 
 	// lowercase the metric and replace spaces with underscores

--- a/cronner.go
+++ b/cronner.go
@@ -92,8 +92,8 @@ func runCommand(cmd *exec.Cmd, label string, save bool, gs *godspeed.Godspeed, l
 	ret, t, err := withLock(cmd, label, gs, lock, lockDir)
 
 	// emit the metric for how long it took us and return code
-	gs.Timing(fmt.Sprintf("cron.%v.time", label), t, nil)
-	gs.Gauge(fmt.Sprintf("cron.%v.exit_code", label), float64(ret), nil)
+	gs.Timing(fmt.Sprintf("%v.time", label), t, nil)
+	gs.Gauge(fmt.Sprintf("%v.exit_code", label), float64(ret), nil)
 
 	return ret, b.Bytes(), t, err
 }
@@ -154,7 +154,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	gs.SetNamespace("pagerduty")
+	gs.SetNamespace(opts.Namespace)
 
 	// get the hostname and validate nothing happened
 	hostname, err := os.Hostname()
@@ -180,7 +180,7 @@ func main() {
 
 	if opts.AllEvents {
 		// emit a DD event to indicate we are starting the job
-		emitEvent(fmt.Sprintf("Cron %v starting on %v", opts.Label, hostname), fmt.Sprintf("UUID:%v\n", uuidStr), opts.Label, "info", uuidStr, gs)
+		emitEvent(fmt.Sprintf("Cron %v starting on %v", opts.Label, hostname), fmt.Sprintf("UUID: %v\n", uuidStr), opts.Label, "info", uuidStr, gs)
 	}
 
 	var saveOutput bool

--- a/cronner_test.go
+++ b/cronner_test.go
@@ -39,7 +39,7 @@ func (t *TestSuite) SetUpSuite(c *C) {
 	var err error
 	t.gs, err = godspeed.NewDefault()
 	c.Assert(err, IsNil)
-	t.gs.SetNamespace("pagerduty")
+	t.gs.SetNamespace("cronner")
 }
 
 func (t *TestSuite) TearDownSuite(c *C) {
@@ -72,7 +72,7 @@ func (t *TestSuite) Test_runCommand(c *C) {
 	stat, ok := <-t.out
 	c.Assert(ok, Equals, true)
 
-	timeStatRegex := regexp.MustCompile("^pagerduty.cron.testCmd.time:([0-9\\.]+)\\|ms$")
+	timeStatRegex := regexp.MustCompile("^cronner.testCmd.time:([0-9\\.]+)\\|ms$")
 	match := timeStatRegex.FindAllStringSubmatch(string(stat), -1)
 	c.Assert(len(match), Equals, 1)
 	c.Assert(len(match[0]), Equals, 2)
@@ -84,7 +84,7 @@ func (t *TestSuite) Test_runCommand(c *C) {
 	stat, ok = <-t.out
 	c.Assert(ok, Equals, true)
 
-	retStatRegex := regexp.MustCompile("^pagerduty.cron.testCmd.exit_code:([0-9\\.]+)\\|g$")
+	retStatRegex := regexp.MustCompile("^cronner.testCmd.exit_code:([0-9\\.]+)\\|g$")
 	match = retStatRegex.FindAllStringSubmatch(string(stat), -1)
 	c.Assert(len(match), Equals, 1)
 	c.Assert(len(match[0]), Equals, 2)


### PR DESCRIPTION
Prior to this patch, `cronner` would set the `pagerduty` namespace on all statsd emissions. The reason for doing this was so end users within PagerDuty wouldn't need to remember to set the proper namespace. The use of the namespace was to avoid any naming collisions with metrics emitted from dd-agent checks.

With the new Chef LWRP around `cronner`, the namespace setting can be done without the humans needing to remember it. So that concern has been alleviated.

In addition, subsequent enhancements by Datadog to their service added some intelligent parsing of statsd metric names. With this change, the inadequacies of using `pagerduty.cron` become apparent as the metrics are grouped under the `pagerduty` service (as they call it). By changing this to `cronner`, it will show up as its own application. This may come in handy at some point.

There are a few other small fixes too:
- fix a spacing issue on one of the UUID lines in the event emission
- remove extra new line from the end of the help output
- improve help output by properly defining the positional arguments in the arg struct
- update documentation to reflect using positional arguments
