### PR TITLE
code restructure/refactor in preparation for open source release

### DIFF
--- a/args.go
+++ b/args.go
@@ -13,8 +13,8 @@ import (
 	"github.com/tideland/goas/v3/logger"
 )
 
-// args is for argument parsing
-type args struct {
+// binArgs is for argument parsing
+type binArgs struct {
 	Label     string `short:"l" long:"label" default:"" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
 	Cmd       string `short:"c" long:"command" default:"" description:"(deprecated; use positional args) command to run (please use full path) and its args; executed as user running cronner"`
 	AllEvents bool   `short:"e" long:"event" default:"false" description:"emit a start and end datadog event"`
@@ -33,7 +33,7 @@ type args struct {
 
 // parse function configures the go-flags parser and runs it
 // it also does some light input validation
-func (a *args) parse() error {
+func (a *binArgs) parse() error {
 	p := flags.NewParser(a, flags.HelpFlag|flags.PassDoubleDash)
 	//p.Usage = Usage
 
@@ -46,7 +46,7 @@ func (a *args) parse() error {
 			logger.Errorf("error: %v\n", err)
 			os.Exit(1)
 		} else {
-			fmt.Printf("%v", err.Error())
+			fmt.Printf("%v", err)
 			os.Exit(0)
 		}
 	}

--- a/runner.go
+++ b/runner.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path"
+	"syscall"
+	"time"
+
+	"github.com/PagerDuty/godspeed"
+	"github.com/nightlyone/lockfile"
+	"github.com/tideland/goas/v3/logger"
+)
+
+const intErrCode = 200
+
+func runCommand(cmd *exec.Cmd, gs *godspeed.Godspeed, opts *binArgs) (int, []byte, float64, error) {
+	// set up the output buffer for the command
+	var b bytes.Buffer
+
+	// comnbine stdout and stderr to the same buffer
+	// if we actually plan on using the command output
+	// otherwise, /dev/null
+	if opts.AllEvents || opts.FailEvent || opts.LogFail {
+		cmd.Stdout = &b
+		cmd.Stderr = &b
+	} else {
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+	}
+
+	// build a new lockFile
+	lockFile, err := lockfile.New(path.Join(opts.LockDir, fmt.Sprintf("cronner-%v.lock", opts.Label)))
+
+	// make sure we weren't given a bad path
+	// and only care if we are doing locking
+	if err != nil && opts.Lock {
+		logger.Criticalf("failure initializing lockfile: %v", err)
+		return intErrCode, nil, 0, err
+	}
+
+	// grab the lock
+	if opts.Lock {
+		if err := lockFile.TryLock(); err != nil {
+			logger.Criticalf("failed to obtain lock on '%v': %v", lockFile, err)
+			return intErrCode, nil, 0, err
+		}
+	}
+
+	// get the current (start) time in the UTC epoch
+	// and run the command
+	s := time.Now().UTC()
+	err = cmd.Run()
+
+	// This next section computes the wallclock run time in ms.
+	// However, there is the unfortunate limitation in that
+	// it uses the clock that gets adjusted by ntpd. Within pure
+	// Go, we don't have access to CLOCK_MONOTONIC_RAW.
+	//
+	// However, based on our usage I don't think we care about it
+	// being off by a few milliseconds.
+	t := time.Since(s).Seconds() * 1000
+
+	// calculate the return code of the command
+	// default to return code 0: success
+	//
+	// this is being done within the lock because
+	// even if we fail to remove the lockfile, we still
+	// need to know what the command did.
+	var ret int
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			status := ee.Sys().(syscall.WaitStatus)
+			ret = status.ExitStatus()
+		} else {
+			ret = intErrCode
+		}
+	}
+
+	// unlock
+	if opts.Lock {
+		if lockErr := lockFile.Unlock(); lockErr != nil {
+			logger.Criticalf("failed to unlock: '%v': %v", lockFile, lockErr)
+
+			// if the command didn't fail, but unlocking did
+			// replace the command error with the unlock error
+			if err == nil {
+				err = lockErr
+			}
+		}
+	}
+
+	// emit the metric for how long it took us and return code
+	gs.Timing(fmt.Sprintf("%v.time", opts.Label), t, nil)
+	gs.Gauge(fmt.Sprintf("%v.exit_code", opts.Label), float64(ret), nil)
+
+	return ret, b.Bytes(), t, err
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"os/exec"
+	"path"
+	"regexp"
+	"runtime"
+	"strconv"
+
+	"github.com/nightlyone/lockfile"
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) Test_runCommand(c *C) {
+	//
+	// Test a command that finishes in 0.3 seconds
+	//
+	cmd := exec.Command("/usr/bin/time", "-p", "/bin/sleep", "0.3")
+
+	// runButts(cmd *exec.Cmd, label string, save bool, gs *godspeed.Godspeed, lock bool, lockDir string)
+	retCode, r, time, err := runCommand(cmd, t.gs, t.a)
+	c.Assert(err, IsNil)
+	c.Assert(retCode, Equals, 0)
+
+	stat, ok := <-t.out
+	c.Assert(ok, Equals, true)
+
+	timeStatRegex := regexp.MustCompile("^cronner.testCmd.time:([0-9\\.]+)\\|ms$")
+	match := timeStatRegex.FindAllStringSubmatch(string(stat), -1)
+	c.Assert(len(match), Equals, 1)
+	c.Assert(len(match[0]), Equals, 2)
+
+	statFloat, err := strconv.ParseFloat(match[0][1], 64)
+	c.Assert(err, IsNil)
+	c.Assert(statFloat, Equals, time)
+
+	stat, ok = <-t.out
+	c.Assert(ok, Equals, true)
+
+	retStatRegex := regexp.MustCompile("^cronner.testCmd.exit_code:([0-9\\.]+)\\|g$")
+	match = retStatRegex.FindAllStringSubmatch(string(stat), -1)
+	c.Assert(len(match), Equals, 1)
+	c.Assert(len(match[0]), Equals, 2)
+
+	retFloat, err := strconv.ParseFloat(match[0][1], 64)
+	c.Assert(err, IsNil)
+	c.Assert(retFloat, Equals, float64(0))
+
+	var timely bool
+
+	// assume the command run time will be within 20ms of correct,
+	// note sure how tight we can make this window without incurring
+	// false-failures.
+	if time > 300 && time < 320 {
+		timely = true
+	}
+	c.Assert(timely, Equals, true)
+
+	timeRegex := regexp.MustCompile("((?m)^real[[:space:]]+([0-9\\.]+)$)")
+	match = timeRegex.FindAllStringSubmatch(string(r), -1)
+	c.Assert(len(match), Equals, 1)
+	c.Assert(len(match[0]), Equals, 3)
+	c.Assert(match[0][2], Equals, "0.30")
+
+	//
+	// Test a command that finishes in 1 second
+	//
+
+	// Reset variables used
+	r = nil
+	err = nil
+	cmd = nil
+	time = 0
+	match = nil
+	timely = false
+	retCode = -512
+	timeRegex = nil
+
+	cmd = exec.Command("/usr/bin/time", "-p", "/bin/sleep", "1")
+
+	retCode, r, time, err = runCommand(cmd, t.gs, t.a)
+	c.Assert(err, IsNil)
+	c.Assert(retCode, Equals, 0)
+
+	stat, ok = <-t.out
+	c.Assert(ok, Equals, true)
+
+	match = timeStatRegex.FindAllStringSubmatch(string(stat), -1)
+	c.Assert(len(match), Equals, 1)
+	c.Assert(len(match[0]), Equals, 2)
+
+	statFloat, err = strconv.ParseFloat(match[0][1], 64)
+	c.Assert(err, IsNil)
+	c.Assert(statFloat, Equals, time)
+
+	if time > 1000 && time < 1020 {
+		timely = true
+	}
+	c.Assert(timely, Equals, true)
+
+	timeRegex = regexp.MustCompile("((?m)^real[[:space:]]+([0-9\\.]+)$)")
+	match = timeRegex.FindAllStringSubmatch(string(r), -1)
+	c.Assert(len(match), Equals, 1)
+	c.Assert(len(match[0]), Equals, 3)
+	c.Assert(match[0][2], Equals, "1.00")
+
+	stat, ok = <-t.out
+	c.Assert(ok, Equals, true)
+
+	match = retStatRegex.FindAllStringSubmatch(string(stat), -1)
+	c.Assert(len(match), Equals, 1)
+	c.Assert(len(match[0]), Equals, 2)
+
+	retFloat, err = strconv.ParseFloat(match[0][1], 64)
+	c.Assert(err, IsNil)
+	c.Assert(retFloat, Equals, float64(0))
+
+	//
+	// Test a valid return code is given
+	//
+
+	// Reset variables used
+	r = nil
+	err = nil
+	cmd = nil
+	time = 0
+	match = nil
+	retCode = -512
+
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("/bin/false")
+	case "darwin":
+		cmd = exec.Command("/usr/bin/false")
+	}
+
+	retCode, r, time, err = runCommand(cmd, t.gs, t.a)
+	c.Assert(err, Not(IsNil))
+	c.Assert(retCode, Equals, 1)
+
+	_, ok = <-t.out
+	c.Assert(ok, Equals, true)
+
+	stat, ok = <-t.out
+	c.Assert(ok, Equals, true)
+
+	match = retStatRegex.FindAllStringSubmatch(string(stat), -1)
+	c.Assert(len(match), Equals, 1)
+	c.Assert(len(match[0]), Equals, 2)
+
+	retFloat, err = strconv.ParseFloat(match[0][1], 64)
+	c.Assert(err, IsNil)
+	c.Assert(retFloat, Equals, float64(1))
+
+	//
+	// Test that no output is given
+	//
+
+	// Reset variables used
+	r = nil
+	err = nil
+	cmd = nil
+	time = 0
+	match = nil
+	retCode = -300
+
+	cmd = exec.Command("/bin/echo", "something")
+
+	t.a.AllEvents = false
+
+	retCode, r, _, err = runCommand(cmd, t.gs, t.a)
+	c.Assert(err, IsNil)
+	c.Assert(retCode, Equals, 0)
+	c.Check(len(r), Equals, 0)
+
+	// clear the statsd return channel
+	_, ok = <-t.out
+	c.Assert(ok, Equals, true)
+	_, ok = <-t.out
+	c.Assert(ok, Equals, true)
+
+	//
+	// Test that locking fails properly when unable to acquire lock
+	//
+
+	// Reset variables used
+	err = nil
+	retCode = -512
+
+	lf, err := lockfile.New(path.Join(t.a.LockDir, "cronner-testCmd.lock"))
+	c.Assert(err, IsNil)
+
+	err = lf.TryLock()
+	c.Assert(err, IsNil)
+	defer lf.Unlock()
+
+	t.a.Lock = true
+
+	retCode, _, _, err = runCommand(cmd, t.gs, t.a)
+	c.Assert(err, Not(IsNil))
+	c.Check(err.Error(), Equals, "Locked by other process")
+	c.Check(retCode, Equals, 200)
+}


### PR DESCRIPTION
The code had some room for improvement. So, since I plan on trying to get this open sourced I wanted to clean it up a little bit.

This moves the command running and logging in to a single function within their own file (`runner.go`).

This also renames the cronner argument struct type to `binArgs` for sanity purposes.
