### PR TITLE
add ability to emit warnings if command is taking too long to finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,20 @@ Usage:
   cronner [OPTIONS] command [arguments]...
 
 Application Options:
-  -l, --label=               name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it
-  -e, --event                emit a start and end datadog event (false)
-  -E, --event-fail           only emit an event on failure (false)
-  -F, --log-fail             when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename (false)
-      --log-path=            where to place the log files for command output (path for -l/--log-on-fail output) (/var/log/cronner/)
-  -L, --log-level=           set the level at which to log at [none|error|info|debug] (error)
-  -s, --sensitive            specify whether command output may contain sensitive details, this only avoids it being printed to stderr (false)
-  -k, --lock                 lock based on label so that multiple commands with the same label can not run concurrently (false)
-  -d, --lock-dir=            the directory where lock files will be placed (/var/lock)
-  -N, --namespace=           namespace for statsd emissions, value is prepended to metric name by statsd client (cronner)
+  -l, --label=                  name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it
+  -e, --event                   emit a start and end datadog event (false)
+  -E, --event-fail              only emit an event on failure (false)
+  -F, --log-fail                when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename (false)
+      --log-path=               where to place the log files for command output (path for -l/--log-on-fail output) (/var/log/cronner/)
+  -L, --log-level=              set the level at which to log at [none|error|info|debug] (error)
+  -s, --sensitive               specify whether command output may contain sensitive details, this only avoids it being printed to stderr (false)
+  -k, --lock                    lock based on label so that multiple commands with the same label can not run concurrently (false)
+  -d, --lock-dir=               the directory where lock files will be placed (/var/lock)
+  -N, --namespace=              namespace for statsd emissions, value is prepended to metric name by statsd client (cronner)
+  -w, --warn-after=N            emit a warning event every N seconds if the job hasn't finished, set to 0 to disable (0)
 
 Help Options:
-  -h, --help                 Show this help message
+  -h, --help                    Show this help message
 
 Arguments:
   command [arguments]

--- a/args.go
+++ b/args.go
@@ -26,6 +26,7 @@ type binArgs struct {
 	Lock      bool   `short:"k" long:"lock" default:"false" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
 	LockDir   string `short:"d" long:"lock-dir" default:"/var/lock" description:"the directory where lock files will be placed"`
 	Namespace string `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
+	WarnAfter uint64 `short:"w" long:"warn-after" default:"0" value-name:"N" description:"emit a warning event every N seconds if the job hasn't finished, set to 0 to disable"`
 	Args      struct {
 		Command []string `positional-arg-name:"command [arguments]"`
 	} `positional-args:"yes" required:"true"`

--- a/cronner.go
+++ b/cronner.go
@@ -107,7 +107,7 @@ func main() {
 	}
 
 	// run the command and return the output as well as the return status
-	ret, out, wallRtMs, err := runCommand(cmd, gs, opts)
+	ret, out, wallRtMs, err := runCommand(cmd, gs, opts, hostname, uuidStr)
 
 	// default variables are for success
 	// we change them later if there was a failure


### PR DESCRIPTION
This adds the ability to have cronner emit a warning DogStatsd event if it hasn't returned yet after every N seconds. So, if you set `--warn-after=5` and your command takes 16 seconds to run, there will be 3 warning events emitted indicating the command is taking longer than expected.

You could then use these warning events in Datadog to trigger alerts.
