### PR TITLE
release cronner as open source under BSD-3 Clause license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+Copyright (c) 2015, PagerDuty Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of PagerDuty nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL PagerDuty OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ If your statsd agent isn't DogStatsD-compliant, I'm not sure what the behavior w
 
 For the finish DogStatsD event, the return code and output of the command are provided in the event body. If the output is too long, it is truncated. This output can optionally be saved to disk only if the job fails for later inspection.
 
-# Usage
+## License
+Cronner is released under the BSD 3-Clause License. See the `LICENSE` file for
+the full contents of the license.
+
+## Usage
 ### Help Output
 
 ```
@@ -73,8 +77,12 @@ cronner.sleepytime2.exit_code:0|g
 _e{55,22}:Cron sleepytime2 succeeded in 5.00565 seconds on rinzler|exit code: 0\\noutput:(none)|k:ab31f2f6-498e-468a-b572-ab990065e8d3|s:cronner|t:success
 ```
 
-# Development
-## Using gpm
+## Contributors
+* Tim Heckman
+* Thomas Dziedzic
+
+## Development
+### Using gpm
 ```
 $ brew install gpm
 
@@ -89,7 +97,7 @@ $ gpm
 $ go build
 ```
 
-## Without gpm
+### Without gpm
 With the configuration above, you won't be able to import any packages within the `cronner` repo from within the codebase.
 In other words, if a cronner file depends on a package in a subdirectory, you wouldn't be able to locate it within the import path.
 To avoid this, you can skip using the gpm approach and use a more manual approach.

--- a/args.go
+++ b/args.go
@@ -1,5 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc.
-// All rights reserved - Do not redistribute!
+// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
 
 package main
 

--- a/cronner.go
+++ b/cronner.go
@@ -1,5 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc.
-// All rights reserved - Do not redistribute!
+// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
 
 // Package main is the main thing, man.
 package main

--- a/cronner_test.go
+++ b/cronner_test.go
@@ -1,5 +1,6 @@
-// Copyright 2014-2015 PagerDuty, Inc.
-// All rights reserved - Do not redistribute!
+// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
 
 package main
 

--- a/runner.go
+++ b/runner.go
@@ -1,3 +1,7 @@
+// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,3 +1,7 @@
+// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package main
 
 import (


### PR DESCRIPTION
This adds a BSD 3-Clause license file, as well as updates the license header on all source files to indicate the source code is copyrighted to PagerDuty, Inc. and its usage is goverened by the BSD 3-Clause license. In addition, a contributors list has been added to the `README.md` file.

In addition, the Development instructions in the `README.md` file have been modified to remove the Godep/gpm suggestion as none of the build steps actually use `gpm` or `Godep` to ensure the right versions of the dependencies are being used. No use suggesting it if we don't actually use it.
