### PR TITLE
add a --wait-secs flag to try and wait for the lock file to clear up

### DIFF
--- a/args.go
+++ b/args.go
@@ -17,21 +17,22 @@ import (
 
 // binArgs is for argument parsing
 type binArgs struct {
-	Cmd        string // this is not a command line flag, but rather parsed results
-	LockDir    string `short:"d" long:"lock-dir" default:"/var/lock" description:"the directory where lock files will be placed"`
-	AllEvents  bool   `short:"e" long:"event" default:"false" description:"emit a start and end datadog event"`
-	FailEvent  bool   `short:"E" long:"event-fail" default:"false" description:"only emit an event on failure"`
-	LogFail    bool   `short:"F" long:"log-fail" default:"false" description:"when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename"`
-	EventGroup string `short:"G" long:"event-group" value-name:"<group>" description:"emit a cronner_group:<group> tag with Datadog events, does not get sent with statsd metrics"`
-	Lock       bool   `short:"k" long:"lock" default:"false" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
-	Label      string `short:"l" long:"label" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
-	LogPath    string `long:"log-path" default:"/var/log/cronner/" description:"where to place the log files for command output (path for -F/--log-fail output)"`
-	LogLevel   string `short:"L" long:"log-level" default:"error" description:"set the level at which to log at [none|error|info|debug]"`
-	Namespace  string `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
-	Sensitive  bool   `short:"s" long:"sensitive" default:"false" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
-	Version    bool   `short:"V" long:"version" description:"print the version string and exit"`
-	WarnAfter  uint64 `short:"w" long:"warn-after" default:"0" value-name:"N" description:"emit a warning event every N seconds if the job hasn't finished, set to 0 to disable"`
-	Args       struct {
+	Cmd         string // this is not a command line flag, but rather parsed results
+	LockDir     string `short:"d" long:"lock-dir" default:"/var/lock" description:"the directory where lock files will be placed"`
+	AllEvents   bool   `short:"e" long:"event" default:"false" description:"emit a start and end datadog event"`
+	FailEvent   bool   `short:"E" long:"event-fail" default:"false" description:"only emit an event on failure"`
+	LogFail     bool   `short:"F" long:"log-fail" default:"false" description:"when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename"`
+	EventGroup  string `short:"G" long:"event-group" value-name:"<group>" description:"emit a cronner_group:<group> tag with Datadog events, does not get sent with statsd metrics"`
+	Lock        bool   `short:"k" long:"lock" default:"false" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
+	Label       string `short:"l" long:"label" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
+	LogPath     string `long:"log-path" default:"/var/log/cronner/" description:"where to place the log files for command output (path for -F/--log-fail output)"`
+	LogLevel    string `short:"L" long:"log-level" default:"error" description:"set the level at which to log at [none|error|info|debug]"`
+	Namespace   string `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
+	Sensitive   bool   `short:"s" long:"sensitive" default:"false" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
+	Version     bool   `short:"V" long:"version" description:"print the version string and exit"`
+	WarnAfter   uint64 `short:"w" long:"warn-after" default:"0" value-name:"N" description:"emit a warning event every N seconds if the job hasn't finished, set to 0 to disable"`
+	WaitSeconds int    `short:"W" long:"wait-secs" default:"0" description:"how long to wait for the file lock for"`
+	Args        struct {
 		Command []string `positional-arg-name:"-- command [arguments]"`
 	} `positional-args:"yes" required:"true"`
 }

--- a/cronner.go
+++ b/cronner.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version is the program's version string
-const Version = "0.1.6"
+const Version = "0.2.0"
 
 type cmdHandler struct {
 	gs       *godspeed.Godspeed


### PR DESCRIPTION
This adds a flag (`-W/--wait-secs`) to want up to N seconds before bailing out due to being unable to acquire the lock file.

Also, bump version to `0.2.0` to follow SemVer.