### PR TITLE
alter argument parsing function to allow unit testing; uprev to v0.2.1

### DIFF
--- a/args.go
+++ b/args.go
@@ -25,51 +25,57 @@ type binArgs struct {
 	EventGroup  string `short:"G" long:"event-group" value-name:"<group>" description:"emit a cronner_group:<group> tag with Datadog events, does not get sent with statsd metrics"`
 	Lock        bool   `short:"k" long:"lock" default:"false" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
 	Label       string `short:"l" long:"label" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
-	LogPath     string `long:"log-path" default:"/var/log/cronner/" description:"where to place the log files for command output (path for -F/--log-fail output)"`
+	LogPath     string `long:"log-path" default:"/var/log/cronner" description:"where to place the log files for command output (path for -F/--log-fail output)"`
 	LogLevel    string `short:"L" long:"log-level" default:"error" description:"set the level at which to log at [none|error|info|debug]"`
 	Namespace   string `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
 	Sensitive   bool   `short:"s" long:"sensitive" default:"false" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
 	Version     bool   `short:"V" long:"version" description:"print the version string and exit"`
 	WarnAfter   uint64 `short:"w" long:"warn-after" default:"0" value-name:"N" description:"emit a warning event every N seconds if the job hasn't finished, set to 0 to disable"`
-	WaitSeconds int    `short:"W" long:"wait-secs" default:"0" description:"how long to wait for the file lock for"`
+	WaitSeconds uint64 `short:"W" long:"wait-secs" default:"0" description:"how long to wait for the file lock for"`
 	Args        struct {
 		Command []string `positional-arg-name:"-- command [arguments]"`
 	} `positional-args:"yes" required:"true"`
 }
 
+var argsLabelRegex = regexp.MustCompile(`^[a-zA-Z0-9_\. ]+$`)
+
 // parse function configures the go-flags parser and runs it
 // it also does some light input validation
-func (a *binArgs) parse() error {
-	p := flags.NewParser(a, flags.HelpFlag|flags.PassDoubleDash)
-	//p.Usage = Usage
+func (a *binArgs) parse(args []string) (string, error) {
+	if args == nil {
+		args = os.Args
+	}
 
-	_, err := p.Parse()
+	p := flags.NewParser(a, flags.HelpFlag|flags.PassDoubleDash)
+
+	_, err := p.ParseArgs(args)
 
 	// determine if there was a parsing error
 	// unfortunately, help message is returned as an error
 	if err != nil {
-		if !strings.Contains(err.Error(), "Usage") {
-			logger.Errorf("error: %v\n", err)
-			os.Exit(1)
-		} else {
-			fmt.Print(err.Error())
-			os.Exit(0)
+		// determine whether this was a help message by doing a type
+		// assertion of err to *flags.Error and check the error type
+		// if it was a help message, do not return an error
+		if errType, ok := err.(*flags.Error); ok {
+			if errType.Type == flags.ErrHelp {
+				return err.Error(), nil
+			}
 		}
+
+		return "", err
 	}
 
 	if a.Version {
-		fmt.Printf("cronner v%s built with %s\nCopyright 2015 PagerDuty, Inc.; released under the BSD 3-Clause License\n", Version, runtime.Version())
-		os.Exit(0)
+		out := fmt.Sprintf("cronner v%s built with %s\nCopyright 2015 PagerDuty, Inc.; released under the BSD 3-Clause License\n", Version, runtime.Version())
+		return out, nil
 	}
 
-	r := regexp.MustCompile("^[a-zA-Z0-9_\\.]+$")
-
-	if !r.MatchString(a.Label) {
-		return fmt.Errorf("cron label '%v' is invalid, it can only be alphanumeric with underscores and periods", a.Label)
+	if !argsLabelRegex.MatchString(a.Label) {
+		return "", fmt.Errorf("cron label '%v' is invalid, it can only be alphanumeric with underscores, periods, and spaces", a.Label)
 	}
 
 	if len(a.Args.Command) == 0 {
-		return fmt.Errorf("you must specify a command to run either using by adding it to the end, or using the command flag")
+		return "", fmt.Errorf("you must specify a command to run either using by adding it to the end, or using the command flag")
 	}
 	a.Cmd = strings.Join(a.Args.Command, " ")
 
@@ -89,9 +95,9 @@ func (a *binArgs) parse() error {
 	case "debug":
 		logLevel = logger.LevelDebug
 	default:
-		return fmt.Errorf("%v is not a known log level, try none, debug, info, or error", a.LogLevel)
+		return "", fmt.Errorf("%v is not a known log level, try none, debug, info, or error", a.LogLevel)
 	}
 	logger.SetLevel(logLevel)
 
-	return nil
+	return "", nil
 }

--- a/args_test.go
+++ b/args_test.go
@@ -1,0 +1,186 @@
+// Copyright 2015 PagerDuty, Inc, et al. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/tideland/goas/v3/logger"
+
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) Test_binArgs_parse(c *C) {
+	var output string
+	var err error
+
+	verOut := fmt.Sprintf("cronner v%s built with %s\nCopyright 2015 PagerDuty, Inc.; released under the BSD 3-Clause License\n", Version, runtime.Version())
+
+	args := &binArgs{}
+	cli := []string{}
+
+	output, err = args.parse(cli)
+	c.Assert(err, Not(IsNil))
+	c.Check(len(output), Equals, 0)
+	c.Check(err.Error(), Equals, "cron label '' is invalid, it can only be alphanumeric with underscores, periods, and spaces")
+
+	args = &binArgs{}
+	cli = []string{"-l", "test"}
+
+	output, err = args.parse(cli)
+	c.Assert(err, Not(IsNil))
+	c.Check(len(output), Equals, 0)
+	c.Check(err.Error(), Equals, "you must specify a command to run either using by adding it to the end, or using the command flag")
+
+	args = &binArgs{}
+	cli = []string{"-V"}
+
+	output, err = args.parse(cli)
+	c.Assert(err, IsNil)
+	c.Check(output, Equals, verOut)
+	c.Check(args.Version, Equals, true)
+
+	args = &binArgs{}
+	cli = []string{"--version"}
+
+	output, err = args.parse(cli)
+	c.Assert(err, IsNil)
+	c.Check(output, Equals, verOut)
+	c.Check(args.Version, Equals, true)
+
+	args = &binArgs{}
+	cli = []string{
+		"-l", "test",
+		"--", "/bin/true",
+	}
+
+	output, err = args.parse(cli)
+	c.Assert(err, IsNil)
+	c.Check(len(output), Equals, 0)
+	c.Check(args.LockDir, Equals, "/var/lock")
+	c.Check(args.AllEvents, Equals, false)
+	c.Check(args.FailEvent, Equals, false)
+	c.Check(args.LogFail, Equals, false)
+	c.Check(args.EventGroup, Equals, "")
+	c.Check(args.Lock, Equals, false)
+	c.Check(args.LogPath, Equals, "/var/log/cronner")
+	c.Check(args.LogLevel, Equals, "error")
+	c.Check(args.Namespace, Equals, "cronner")
+	c.Check(args.Sensitive, Equals, false)
+	c.Check(args.Version, Equals, false)
+	c.Check(args.WarnAfter, Equals, uint64(0))
+	c.Check(args.WaitSeconds, Equals, uint64(0))
+
+	args = &binArgs{}
+	cli = []string{
+		"-d", "/var/testlock",
+		"-e",
+		"-E",
+		"-F",
+		"-G", "test_group",
+		"-k",
+		"-l", "test",
+		"-L", "info",
+		"-N", "testcronner",
+		"-s",
+		"-w", "42",
+		"-W", "84",
+		"--", "/bin/true",
+	}
+
+	output, err = args.parse(cli)
+	c.Assert(err, IsNil)
+
+	// because we're parsing args we've just overridden this in the parser
+	// so set it back to the value from SetUpSuite()
+	logger.SetLevel(logger.LevelFatal)
+
+	c.Check(len(output), Equals, 0)
+	c.Check(args.LockDir, Equals, "/var/testlock")
+	c.Check(args.AllEvents, Equals, true)
+	c.Check(args.FailEvent, Equals, true)
+	c.Check(args.LogFail, Equals, true)
+	c.Check(args.EventGroup, Equals, "test_group")
+	c.Check(args.Lock, Equals, true)
+	c.Check(args.Label, Equals, "test")
+	c.Check(args.LogLevel, Equals, "info")
+	c.Check(args.Namespace, Equals, "testcronner")
+	c.Check(args.Sensitive, Equals, true)
+	c.Check(args.Version, Equals, false)
+	c.Check(args.WarnAfter, Equals, uint64(42))
+	c.Check(args.WaitSeconds, Equals, uint64(84))
+	c.Assert(len(args.Args.Command), Equals, 1)
+	c.Check(args.Args.Command[0], Equals, "/bin/true")
+
+	args = &binArgs{}
+	cli = []string{
+		"--lock-dir", "/var/testlock",
+		"--event",
+		"--event-fail",
+		"--log-fail",
+		"--event-group", "test_group",
+		"--lock",
+		"--label", "test",
+		"--log-path", "/var/log/testcronner",
+		"--log-level", "info",
+		"--namespace", "testcronner",
+		"--sensitive",
+		"--warn-after", "42",
+		"--wait-secs", "84",
+		"--", "/bin/true",
+	}
+
+	output, err = args.parse(cli)
+	c.Assert(err, IsNil)
+	logger.SetLevel(logger.LevelFatal)
+
+	c.Check(len(output), Equals, 0)
+	c.Check(args.LockDir, Equals, "/var/testlock")
+	c.Check(args.AllEvents, Equals, true)
+	c.Check(args.FailEvent, Equals, true)
+	c.Check(args.LogFail, Equals, true)
+	c.Check(args.EventGroup, Equals, "test_group")
+	c.Check(args.Lock, Equals, true)
+	c.Check(args.Label, Equals, "test")
+	c.Check(args.LogPath, Equals, "/var/log/testcronner")
+	c.Check(args.LogLevel, Equals, "info")
+	c.Check(args.Namespace, Equals, "testcronner")
+	c.Check(args.Sensitive, Equals, true)
+	c.Check(args.Version, Equals, false)
+	c.Check(args.WarnAfter, Equals, uint64(42))
+	c.Check(args.WaitSeconds, Equals, uint64(84))
+	c.Assert(len(args.Args.Command), Equals, 1)
+	c.Check(args.Args.Command[0], Equals, "/bin/true")
+
+	args = &binArgs{}
+	cli = []string{
+		"--lock-dir=/var/testlock",
+		"--event-group=test_group",
+		"--label=test",
+		"--log-path=/var/log/testcronner",
+		"--log-level=info",
+		"--namespace=testcronner",
+		"--warn-after=42",
+		"--wait-secs=84",
+		"--", "/bin/true",
+	}
+
+	output, err = args.parse(cli)
+	c.Assert(err, IsNil)
+	logger.SetLevel(logger.LevelFatal)
+
+	c.Check(len(output), Equals, 0)
+	c.Check(args.LockDir, Equals, "/var/testlock")
+	c.Check(args.EventGroup, Equals, "test_group")
+	c.Check(args.Label, Equals, "test")
+	c.Check(args.LogPath, Equals, "/var/log/testcronner")
+	c.Check(args.LogLevel, Equals, "info")
+	c.Check(args.Namespace, Equals, "testcronner")
+	c.Check(args.WarnAfter, Equals, uint64(42))
+	c.Check(args.WaitSeconds, Equals, uint64(84))
+	c.Assert(len(args.Args.Command), Equals, 1)
+	c.Check(args.Args.Command[0], Equals, "/bin/true")
+}

--- a/cronner.go
+++ b/cronner.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -16,7 +17,7 @@ import (
 )
 
 // Version is the program's version string
-const Version = "0.2.0"
+const Version = "0.2.1"
 
 type cmdHandler struct {
 	gs       *godspeed.Godspeed
@@ -31,12 +32,18 @@ func main() {
 
 	// get and parse the command line options
 	opts := &binArgs{}
-	err := opts.parse()
+	output, err := opts.parse(nil)
 
 	// make sure parsing didn't bomb
 	if err != nil {
 		logger.Errorf("error: %v\n", err)
 		os.Exit(1)
+	}
+
+	// if parsing had output, print it and exit 0
+	if len(output) > 0 {
+		fmt.Print(output)
+		os.Exit(0)
 	}
 
 	// build a Godspeed client


### PR DESCRIPTION
The `*binArgs.parse()` function has been modified to return a string and an error. Previously, the function would just print and exit on its own. However, by changing this behavior we can now properly test the funciton to ensure argument parsing happens as expected.

If argument parsing succeeds, and we should continue with normal operation, the string and error values will be their defaults (`""`, and `nil` respectively). If the string value is non-empty, we should print the value and exit status 0. If the error value is present, we should log the error and exit with status 1.