### PR TITLE
bump go runtime to go1.5.1; uprev to 0.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.5
+- 1.5.1
 addons:
   apt:
     packages:

--- a/cronner.go
+++ b/cronner.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version is the program's version string
-const Version = "0.2.1"
+const Version = "0.2.2"
 
 type cmdHandler struct {
 	gs       *godspeed.Godspeed


### PR DESCRIPTION
There is a new go runtime available. Let's build against that, and give the new build `v0.2.2`.