### PR TITLE
[heckbug] fix bug in argument parsing function; add regression test

### DIFF
--- a/args.go
+++ b/args.go
@@ -41,6 +41,8 @@ var argsLabelRegex = regexp.MustCompile(`^[a-zA-Z0-9_\. ]+$`)
 
 // parse function configures the go-flags parser and runs it
 // it also does some light input validation
+//
+// the args parameter is meant to be the entirety of os.Args
 func (a *binArgs) parse(args []string) (string, error) {
 	if args == nil {
 		args = os.Args
@@ -48,7 +50,7 @@ func (a *binArgs) parse(args []string) (string, error) {
 
 	p := flags.NewParser(a, flags.HelpFlag|flags.PassDoubleDash)
 
-	_, err := p.ParseArgs(args)
+	_, err := p.ParseArgs(args[1:])
 
 	// determine if there was a parsing error
 	// unfortunately, help message is returned as an error


### PR DESCRIPTION
As part of `v0.2.1` the argument parsing function was refactored to allow unit testing / better behaviors on failure. Unit tests were written and seemed to confirm that argument parsing was working as expected. However, it was not.

As part of the refactor, the call to the parsing function in our argument parsing package was changed:

* https://github.com/PagerDuty/cronner/commit/266daff445c1bb161c04ba7dc2e93b040f8006cb#diff-07ee57a49d1c0b692bd79676cc31dd6fR51

This seems like a fairly innocuous change, until you look at what the `Parse()` function does in the package:

* https://github.com/jessevdk/go-flags/blob/1acbbaff2f347c412a0c7884873bd72cc9c1f5b4/parser.go#L153-L155

The fatal flaw was that I forgot argument 0 is always the process being called. As such, my test data was not realistic and seemed to pass without issue. However, functional testing proved otherwise.

This patch changes the `ParseArgs()` function call to lob off element 0 in the `args` slice. The tests were also updated with a regression test which should catch this failure if it ever creeps up again.