### PR TITLE
uprev cronner to v0.2.3

### DIFF
--- a/cronner.go
+++ b/cronner.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version is the program's version string
-const Version = "0.2.2"
+const Version = "0.2.3"
 
 type cmdHandler struct {
 	gs       *godspeed.Godspeed


### PR DESCRIPTION
This is for when #42 gets merged. It fixes a bug in the argument parsing code and updates tests to catch the error if it were to regress.