### PR TITLE
improve argument parsing to handle quoted arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ _testmain.go
 
 src
 pkg
+
+testlog/

--- a/args.go
+++ b/args.go
@@ -17,21 +17,22 @@ import (
 
 // binArgs is for argument parsing
 type binArgs struct {
-	Cmd         string // this is not a command line flag, but rather parsed results
-	LockDir     string `short:"d" long:"lock-dir" default:"/var/lock" description:"the directory where lock files will be placed"`
-	AllEvents   bool   `short:"e" long:"event" default:"false" description:"emit a start and end datadog event"`
-	FailEvent   bool   `short:"E" long:"event-fail" default:"false" description:"only emit an event on failure"`
-	LogFail     bool   `short:"F" long:"log-fail" default:"false" description:"when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename"`
-	EventGroup  string `short:"G" long:"event-group" value-name:"<group>" description:"emit a cronner_group:<group> tag with Datadog events, does not get sent with statsd metrics"`
-	Lock        bool   `short:"k" long:"lock" default:"false" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
-	Label       string `short:"l" long:"label" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
-	LogPath     string `long:"log-path" default:"/var/log/cronner" description:"where to place the log files for command output (path for -F/--log-fail output)"`
-	LogLevel    string `short:"L" long:"log-level" default:"error" description:"set the level at which to log at [none|error|info|debug]"`
-	Namespace   string `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
-	Sensitive   bool   `short:"s" long:"sensitive" default:"false" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
-	Version     bool   `short:"V" long:"version" description:"print the version string and exit"`
-	WarnAfter   uint64 `short:"w" long:"warn-after" default:"0" value-name:"N" description:"emit a warning event every N seconds if the job hasn't finished, set to 0 to disable"`
-	WaitSeconds uint64 `short:"W" long:"wait-secs" default:"0" description:"how long to wait for the file lock for"`
+	Cmd         string   // this is not a command line flag, but rather parsed results
+	CmdArgs     []string // this is not a command line flag, also parsed results
+	LockDir     string   `short:"d" long:"lock-dir" default:"/var/lock" description:"the directory where lock files will be placed"`
+	AllEvents   bool     `short:"e" long:"event" default:"false" description:"emit a start and end datadog event"`
+	FailEvent   bool     `short:"E" long:"event-fail" default:"false" description:"only emit an event on failure"`
+	LogFail     bool     `short:"F" long:"log-fail" default:"false" description:"when a command fails, log its full output (stdout/stderr) to the log directory using the UUID as the filename"`
+	EventGroup  string   `short:"G" long:"event-group" value-name:"<group>" description:"emit a cronner_group:<group> tag with Datadog events, does not get sent with statsd metrics"`
+	Lock        bool     `short:"k" long:"lock" default:"false" description:"lock based on label so that multiple commands with the same label can not run concurrently"`
+	Label       string   `short:"l" long:"label" description:"name for cron job to be used in statsd emissions and DogStatsd events. alphanumeric only; cronner will lowercase it"`
+	LogPath     string   `long:"log-path" default:"/var/log/cronner" description:"where to place the log files for command output (path for -F/--log-fail output)"`
+	LogLevel    string   `short:"L" long:"log-level" default:"error" description:"set the level at which to log at [none|error|info|debug]"`
+	Namespace   string   `short:"N" long:"namespace" default:"cronner" description:"namespace for statsd emissions, value is prepended to metric name by statsd client"`
+	Sensitive   bool     `short:"s" long:"sensitive" default:"false" description:"specify whether command output may contain sensitive details, this only avoids it being printed to stderr"`
+	Version     bool     `short:"V" long:"version" description:"print the version string and exit"`
+	WarnAfter   uint64   `short:"w" long:"warn-after" default:"0" value-name:"N" description:"emit a warning event every N seconds if the job hasn't finished, set to 0 to disable"`
+	WaitSeconds uint64   `short:"W" long:"wait-secs" default:"0" description:"how long to wait for the file lock for"`
 	Args        struct {
 		Command []string `positional-arg-name:"-- command [arguments]"`
 	} `positional-args:"yes" required:"true"`
@@ -79,7 +80,11 @@ func (a *binArgs) parse(args []string) (string, error) {
 	if len(a.Args.Command) == 0 {
 		return "", fmt.Errorf("you must specify a command to run either using by adding it to the end, or using the command flag")
 	}
-	a.Cmd = strings.Join(a.Args.Command, " ")
+	a.Cmd = a.Args.Command[0]
+
+	if len(a.Args.Command) > 1 {
+		a.CmdArgs = a.Args.Command[1:]
+	}
 
 	// lowercase the metric and replace spaces with underscores
 	// to try and encourage sanity

--- a/cronner.go
+++ b/cronner.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/PagerDuty/godspeed"
 	"github.com/codeskyblue/go-uuid"
@@ -65,21 +64,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// split the command in to its binary and arguments
-	cmdParts := strings.Split(opts.Cmd, " ")
-
-	// build the args slice
-	var args []string
-	if len(cmdParts) > 1 {
-		args = cmdParts[1:]
-	}
-
 	handler := &cmdHandler{
 		opts:     opts,
 		hostname: hostname,
 		gs:       gs,
 		uuid:     uuid.New(),
-		cmd:      exec.Command(cmdParts[0], args...),
+		cmd:      exec.Command(opts.Cmd, opts.CmdArgs...),
 	}
 
 	ret, _, _, err := handleCommand(handler)


### PR DESCRIPTION
The argument parsing code made a fatal flaw where it wouldn't work with an invocation like this:

```
cronner -l testjob -- /test/command "argument 1"
```

The old code split the `argument one` string in to two separate arguments. This fixes that and adds tests for it.

Fixes #44.

@rduffield 