### PR TITLE
test/build cronner against Go 1.5.3; v0.2.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.5.1
+- 1.5.3
 addons:
   apt:
     packages:

--- a/cronner.go
+++ b/cronner.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version is the program's version string
-const Version = "0.2.4"
+const Version = "0.2.5"
 
 type cmdHandler struct {
 	gs       *godspeed.Godspeed


### PR DESCRIPTION
This changes the Go runtime version of `cronner` to use Go 1.5.3. We also bump the release version number to `v0.2.5` to cut a new release.